### PR TITLE
updated for NZ case: updated bounds and fixed interp by masking to native coverage

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -111,7 +111,7 @@ domains:
     data_type: "NZCSM"
     grid:
       mode: regular
-      lat_bounds: [-49, -30]
-      lon_bounds: [160, 185]
+      lat_bounds: [-50.5, -31]
+      lon_bounds: [163, 182]
       dlat: 0.02
       dlon: 0.02

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -111,7 +111,7 @@ domains:
     data_type: "NZCSM"
     grid:
       mode: regular
-      lat_bounds: [-50.5, -31]
-      lon_bounds: [163, 182]
+      lat_bounds: [-49.0, -30.2]
+      lon_bounds: [160.5, 184.8]
       dlat: 0.02
       dlon: 0.02

--- a/met_extract/rotated.py
+++ b/met_extract/rotated.py
@@ -74,14 +74,15 @@ def regrid_to_latlon(cube, target_cube, scheme=None):
     target_cube : iris.cube.Cube
         Target grid from :func:`latlon_target_cube`.
     scheme : iris regridding scheme, optional
-        Defaults to ``iris.analysis.Linear()``.
+        Defaults to ``iris.analysis.Linear(extrapolation_mode="mask")``: data points
+        outside native grid coverage are masked rather than extrapolated.
 
     Returns
     -------
     iris.cube.Cube
         Regridded cube on the target lat/lon grid.
     """
-    return cube.regrid(target_cube, scheme or Linear())
+    return cube.regrid(target_cube, scheme or Linear(extrapolation_mode="mask"))
 
 
 def rotate_winds_true_north(u_cube, v_cube, mass_cube, earth_radius=UM_EARTH_RADIUS):
@@ -132,6 +133,7 @@ def rotated_pole_attrs(cube):
         "native_grid_north_pole_longitude": float(cs.grid_north_pole_longitude),
         "regridding": (
             "regridded from the native rotated-pole grid to a regular lat/lon grid "
-            "(bilinear); wind/stress vectors rotated to true north beforehand"
+            "(bilinear, edge points outside native coverage masked); "
+            "wind/stress vectors rotated to true north beforehand"
         ),
     }


### PR DESCRIPTION
I've done some testing, and no interpolation method seems to work well outside the bounds of the domain. Historically, the domain is sufficient for all work we've done, so I think the coverage is probably okay?
I've tested masking to the native coverage, simple change in the Linear() method and seems to work well. It turns data points with no data into NaNs. Can change if this will cause issues down the line. I made this change within the regrid_to_latlon function directly as it seems only the NZ case would call this function?
I've also changed the lat/lon bounds in the config so that all valid data is included, but can cut down if too many NaNs (see plot).

<img width="833" height="728" alt="image" src="https://github.com/user-attachments/assets/95cb36e0-4c68-4e26-8e72-f54c11401735" />
